### PR TITLE
Fix deploy build path

### DIFF
--- a/.github/workflows/main_app-001-step3-1-suzuyu-node-62.yml
+++ b/.github/workflows/main_app-001-step3-1-suzuyu-node-62.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir -p deploy
           # Standaloneモードのビルド成果物をコピー
-          cp -r ./build/* ./deploy/
+          cp -r ./build ./deploy/
           # server.jsは確実にコピー
           cp server.js ./deploy/
           cp web.config ./deploy/


### PR DESCRIPTION
## Summary
- ensure Next.js build folder is copied during deployment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684476a216d883318e736c7091a55f8d